### PR TITLE
Potential fix for code scanning alert no. 8: Inefficient regular expression

### DIFF
--- a/docs/site/home/js/prism.js
+++ b/docs/site/home/js/prism.js
@@ -2069,7 +2069,7 @@ Prism.languages.js = Prism.languages.javascript;
 				inside: createInterpolationInside(mInterpolation, mInterpolationRound),
 			},
 			{
-				pattern: re(/(^|[^@\\])\$"(?:\\.|\{\{|<<0>>|[^\\"{])*"/.source, [sInterpolation]),
+				pattern: re(/(^|[^@\\])\$"(?:\\.|\{\{|<<0>>|[^\\"{<]|<(?!<0>>))*"/.source, [sInterpolation]),
 				lookbehind: true,
 				greedy: true,
 				inside: createInterpolationInside(sInterpolation, sInterpolationRound),


### PR DESCRIPTION
Potential fix for [https://github.com/JupiterOne/tinkerpop/security/code-scanning/8](https://github.com/JupiterOne/tinkerpop/security/code-scanning/8)

General fix approach: remove ambiguity inside the repeated alternation by ensuring generic branches cannot consume prefixes of specific multi-character branches. Practically, exclude `<` from the fallback character class so `<<0>>` is matched only by its dedicated alternative.

Best minimal functional fix in `docs/site/home/js/prism.js`:
- Update line 2072 pattern from:
  `/(^|[^@\\])\$"(?:\\.|\{\{|<<0>>|[^\\"{])*"/`
- To:
  `/(^|[^@\\])\$"(?:\\.|\{\{|<<0>>|[^\\"{<]|<(?!<0>>))*"/`

Why this preserves behavior:
- Previously `<` was consumed by `[^\\"{]`.
- Now `<` is consumed either as part of `<<0>>` or as a single `<` when it is **not** the start of `<<0>>` (`<(?!<0>>)`).
- This removes the key overlap causing excessive backtracking while keeping accepted strings equivalent.

No imports, helper methods, or dependency changes are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
